### PR TITLE
Make compatible with Jekyll 3

### DIFF
--- a/lib/jekyll-markdown-block.rb
+++ b/lib/jekyll-markdown-block.rb
@@ -11,7 +11,12 @@ module Jekyll
     #
     def render(context)
       site = context.registers[:site]
-      converter = site.getConverterImpl(::Jekyll::Converters::Markdown)
+      converter =
+      if site.respond_to?(:find_converter_instance)
+        site.find_converter_instance(Jekyll::Converters::Markdown)
+      else
+        site.getConverterImpl(Jekyll::Converters::Markdown)
+      end
       converter.convert(render_block(context))
     end
   end


### PR DESCRIPTION
This patch adds a test so the plugin works with both Jekyll 2 and 3.

Thank for this plugin. We use it extensively on a intranet site at FSU Biology's graduate office.
